### PR TITLE
Update CI branch from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Change the CI configuration to use the correct branch name, updating from 'master' to 'main'.